### PR TITLE
fix issue with REF count 0 in fix ref script

### DIFF
--- a/scripts/fix-ref/fix_ensembletr_snpstr_reference.py
+++ b/scripts/fix-ref/fix_ensembletr_snpstr_reference.py
@@ -47,7 +47,9 @@ def GetAlleleCounts(record):
     allele_counts = {}
     for a in alleles:
         acount = all_allele_calls.count(a)
-        if acount > 0: allele_counts[a] = acount
+        # Note: force REF to be in dict even if acount=0
+        if acount > 0 or a == record.REF:
+            allele_counts[a] = acount
     # Keep order same as original
     allele_order = [item for item in alleles if item in allele_counts.keys()]
     return allele_counts, allele_order


### PR DESCRIPTION
The script `fix_ensembletr_snpstr_reference.py` removes alleles from the TR+SNP reference that have 0 count. In cases where 0 samples had the REF allele, this caused the REF allele to be removed resulting in an incorrect REF for the VCF. Now even if the reference allele has 0 count, we keep it in the list of alleles considered.